### PR TITLE
New Modding API for custom Needs and Zones.

### DIFF
--- a/SimAirport.Modding.Base/Data/Example/ExampleMod.cs
+++ b/SimAirport.Modding.Base/Data/Example/ExampleMod.cs
@@ -6,9 +6,7 @@ using TerrainTools;
 using UnityEngine;
 
 namespace SimAirport.Modding.Data.Example {
-
     public class ExampleMod : BaseMod {
-
         public override string InternalName => "Example.Mod.Internal.Name";
         public override string Name => "example.mod.name"; // i18n not working: i18n.Get("example.mod.name");
         public override string Description => "example.mod.desc"; // i18n not working: i18n.Get("example.mod.desc");
@@ -23,16 +21,14 @@ namespace SimAirport.Modding.Data.Example {
             new ZoneManager(ZoneManagerInternals.InternalRegisterZone, ZoneManagerInternals.InternalUnregisterZone);
         }
 
-
         private ZoneTool exampleZoneTool;
 
         public override void OnLoad(global::GameState state) {
-
             exampleZoneTool = ZoneManager.Instance.RegisterZone<ExampleZone>("example.zone.guid", new ZoneToolConfig() {
                 ZoneSpriteKey = "example.zone.sprite", // set key for sprite used for zone overlay 
                 ToolSpriteKey = "example.tool.sprite", // set key for sprite used as icon in zone menu
-                I18nNameKey   = "example.zone.name",   // i18n for zone name (overlay & zone menu)
-                I18nDescKey   = "example.zone.desc",   // i18n for zone desc in zone menu
+                I18nNameKey = "example.zone.name",   // i18n for zone name (overlay & zone menu)
+                I18nDescKey = "example.zone.desc",   // i18n for zone desc in zone menu
 
                 requiresEnclosedSpace = true,
                 requiredMinSize = new Vector2(2, 3),
@@ -49,7 +45,5 @@ namespace SimAirport.Modding.Data.Example {
 
             NeedManager.Instance.UnregisterNeed<ExampleNeed>();
         }
-
     }
-
 }

--- a/SimAirport.Modding.Base/Data/Example/ExampleMod.cs
+++ b/SimAirport.Modding.Base/Data/Example/ExampleMod.cs
@@ -1,0 +1,55 @@
+﻿using SimAirport.Modding.Base;
+using SimAirport.Modding.Data.ImplementationDetails.Example;
+using SimAirport.Modding.Data.NewInternals;
+using SimAirport.Modding.Settings;
+using TerrainTools;
+using UnityEngine;
+
+namespace SimAirport.Modding.Data.Example {
+
+    public class ExampleMod : BaseMod {
+
+        public override string InternalName => "Example.Mod.Internal.Name";
+        public override string Name => "example.mod.name"; // i18n not working: i18n.Get("example.mod.name");
+        public override string Description => "example.mod.desc"; // i18n not working: i18n.Get("example.mod.desc");
+        public override string Author => "BR146";
+        public override SettingManager SettingManager { get; set; }
+
+        public override void OnTick() { }
+
+        public ExampleMod() : base() {
+            // This should happen internally
+            new NeedManager(NeedManagerInternals.InternalRegisterNeed, NeedManagerInternals.InternalUnregisterNeed);
+            new ZoneManager(ZoneManagerInternals.InternalRegisterZone, ZoneManagerInternals.InternalUnregisterZone);
+        }
+
+
+        private ZoneTool exampleZoneTool;
+
+        public override void OnLoad(global::GameState state) {
+
+            exampleZoneTool = ZoneManager.Instance.RegisterZone<ExampleZone>("example.zone.guid", new ZoneToolConfig() {
+                ZoneSpriteKey = "example.zone.sprite", // set key for sprite used for zone overlay 
+                ToolSpriteKey = "example.tool.sprite", // set key for sprite used as icon in zone menu
+                I18nNameKey   = "example.zone.name",   // i18n for zone name (overlay & zone menu)
+                I18nDescKey   = "example.zone.desc",   // i18n for zone desc in zone menu
+
+                requiresEnclosedSpace = true,
+                requiredMinSize = new Vector2(2, 3),
+                maximum_of_zone_type = -1
+            });
+
+            NeedManager.Instance.RegisterNeed<ExampleNeed>();
+        }
+
+        public override void OnDisabled() {
+            // Not exactly sure what will happen on save/load
+
+            ZoneManager.Instance.UnregisterZone(exampleZoneTool);
+
+            NeedManager.Instance.UnregisterNeed<ExampleNeed>();
+        }
+
+    }
+
+}

--- a/SimAirport.Modding.Base/Data/Example/ExampleNeed.cs
+++ b/SimAirport.Modding.Base/Data/Example/ExampleNeed.cs
@@ -2,15 +2,13 @@
 using UnityEngine;
 
 namespace SimAirport.Modding.Data.Example {
-    class ExampleNeed : Need {
+    public class ExampleNeed : Need {
         public string I18nKeyName => "example.need.name";
 
         private readonly NeedConfig agentConfig;
         protected override NeedConfig config => agentConfig;
 
         public override bool impactsSatisfaction => true;
-
-
 
         public ExampleNeed() {
             agentConfig = ScriptableObject.CreateInstance<NeedConfig>();

--- a/SimAirport.Modding.Base/Data/Example/ExampleNeed.cs
+++ b/SimAirport.Modding.Base/Data/Example/ExampleNeed.cs
@@ -1,0 +1,32 @@
+﻿using Needs;
+using UnityEngine;
+
+namespace SimAirport.Modding.Data.Example {
+    class ExampleNeed : Need {
+        public string I18nKeyName => "example.need.name";
+
+        private readonly NeedConfig agentConfig;
+        protected override NeedConfig config => agentConfig;
+
+        public override bool impactsSatisfaction => true;
+
+
+
+        public ExampleNeed() {
+            agentConfig = ScriptableObject.CreateInstance<NeedConfig>();
+
+            agentConfig.Init = new Vector2(0.7f, 1.0f); // start score
+            agentConfig.Tick = 1f / (6f * 60f * 18f);  // how fast the need is rising? % per tick @ 18 ticks per second? NOTE: score = Mathf.Clamp01(score + tick * deltaTime);
+            agentConfig.Activation = 0.1f; // threshold to trigger end of need satificaton?
+
+            agentConfig.curve = new ThreadsafeCurve();
+            agentConfig.curve.SetCurve(AnimationCurve.Linear(0, 0, 1, 1));
+        }
+
+        public override void Configure() {
+            if( agent.isExecutive ) { // executives don't need this need ;)
+                enabled = false;
+            }
+        }
+    }
+}

--- a/SimAirport.Modding.Base/Data/Example/ExampleZone.cs
+++ b/SimAirport.Modding.Base/Data/Example/ExampleZone.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SimAirport.Modding.Data.ImplementationDetails.Example {
+    class ExampleZone : Zone {
+        protected ExampleZone(ZoneType type) : base(type) {
+        }
+
+        private void ACheck(out bool isOnLevel) {
+            isOnLevel = Level == 2; // only functional on Level 2
+        }
+
+        public override bool MeetsRequirements(bool cacheBuster = false) {
+
+            if( ShouldCheckRequirements(cacheBuster) ) {
+                base.MeetsRequirements(cacheBuster);
+
+                ACheck(out bool isOnLevel);
+
+                cachedMet &= isOnLevel;
+            }
+
+            return cachedMet;
+        }
+
+
+        public override StringBuilder GetFormattedErrors() {
+            base.GetFormattedErrors();
+
+            ACheck(out bool isOnLevel);
+
+            Util.passfailAppend(isOnLevel, i18n.Get("example.zone.requires.level2"), null, formatted_errors);
+
+            return formatted_errors;
+        }
+    }
+}

--- a/SimAirport.Modding.Base/Data/Example/ExampleZone.cs
+++ b/SimAirport.Modding.Base/Data/Example/ExampleZone.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Text;
 
 namespace SimAirport.Modding.Data.ImplementationDetails.Example {
-    class ExampleZone : Zone {
+    public class ExampleZone : Zone {
         protected ExampleZone(ZoneType type) : base(type) {
         }
 
@@ -14,7 +10,6 @@ namespace SimAirport.Modding.Data.ImplementationDetails.Example {
         }
 
         public override bool MeetsRequirements(bool cacheBuster = false) {
-
             if( ShouldCheckRequirements(cacheBuster) ) {
                 base.MeetsRequirements(cacheBuster);
 
@@ -25,7 +20,6 @@ namespace SimAirport.Modding.Data.ImplementationDetails.Example {
 
             return cachedMet;
         }
-
 
         public override StringBuilder GetFormattedErrors() {
             base.GetFormattedErrors();

--- a/SimAirport.Modding.Base/Data/ImplementationDetails/NeedManagerInternals.cs
+++ b/SimAirport.Modding.Base/Data/ImplementationDetails/NeedManagerInternals.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SimAirport.Modding.Data.NewInternals {
-    class NeedManagerInternals {
+    internal static class NeedManagerInternals {
         /// <summary>
         /// Internal global list with all modded registered needs.
         /// </summary>

--- a/SimAirport.Modding.Base/Data/ImplementationDetails/NeedManagerInternals.cs
+++ b/SimAirport.Modding.Base/Data/ImplementationDetails/NeedManagerInternals.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SimAirport.Modding.Data.NewInternals {
+    class NeedManagerInternals {
+        /// <summary>
+        /// Internal global list with all modded registered needs.
+        /// </summary>
+        internal static List<Type> customNeedTypes = new List<Type>();
+
+        internal static void InternalRegisterNeed(Type tNeed) {
+            if( !customNeedTypes.Contains(tNeed) ) {
+                customNeedTypes.Add(tNeed);
+            }
+        }
+
+        internal static void InternalUnregisterNeed(Type tNeed) {
+            customNeedTypes.Remove(tNeed);
+        }
+    }
+}

--- a/SimAirport.Modding.Base/Data/ImplementationDetails/NeedPatches.cs
+++ b/SimAirport.Modding.Base/Data/ImplementationDetails/NeedPatches.cs
@@ -1,0 +1,92 @@
+﻿using Needs;
+using Newtonsoft.Json;
+using System;
+
+namespace SimAirport.Modding.Data.NewInternals {
+    class NeedPatches {
+
+
+        /// <summary>
+        /// Interface which modded needs _must_ implemenent.
+        /// 
+        /// It provides hooks for the ingame logic to call custom behaviour.
+        /// 
+        /// May be integrated directly into Needs.Need class?
+        /// </summary>
+        public class Need_Modifications : Need {
+
+            /// <summary>
+            /// Translation key for the need's name.
+            /// </summary>
+            [JsonIgnore]
+            public string I18nKeyName { get; }
+
+            [JsonIgnore]
+            public string localizedName {
+                get {
+                    if( string.IsNullOrEmpty(I18nKeyName) ) {
+                        return i18n.Get(string.Format("UI.strings.needs.{0}", GetType().ToString().Replace("Needs.", "")));
+                    } else {
+                        return i18n.Get(I18nKeyName);
+                    }
+                }
+            }
+
+
+            /// <summary>
+            /// Called for each new agent (like pax, executives) to configure the need for
+            /// each individually.
+            /// </summary>
+            public virtual void Configure() { }
+        }
+
+
+
+        /***
+            * Attach hook to NeedManager.AddAllNeeds
+            * 
+            * AddAllNeeds adds all vanilla needs to the manager for a new agent.
+            * Hook into this to attach all (currently) known custom needs.
+            * 
+            * Note: New needs will only affect new spawnt agents.
+            */
+        [HarmonyPatch(typeof(NeedManager))]
+        [HarmonyPatch("AddAllNeeds")]
+        static class NeedManager_AddAllNeeds {
+            //private void AddAllNeeds()
+
+            static void Postfix(global::Needs.NeedManager __instance) {
+                foreach( var needType in NeedManagerInternals.customNeedTypes ) {
+                    // NeedManager.Add<> is private and looking it up is more complex than just reimplement add.
+                    // This block is almost identical to NeedManager.Add<T>
+
+                    Need need = (Need)Activator.CreateInstance(needType);
+                    need.SetAgent(__instance.agent);
+                    __instance.needs.Add(need);
+                    __instance.needsByType[need.GetType()] = need;
+                }
+            }
+        }
+
+        /***
+            * Attach hook to NeedManager.Configure
+            * 
+            * Configure each custom need for the current agent, e. g. not active for managers.
+            * As each need could be different, this does happen for each (custom) need.
+            * 
+            * With above integration of Configure() into Need class, we can simply call Configure() for every need.
+            * But this depends if checking for modded need is heavier than running an empty virtual method...
+            */
+        [HarmonyPatch(typeof(global::Needs.NeedManager))]
+        [HarmonyPatch(nameof(global::Needs.NeedManager.Configure))]
+        static class NeedManager_Configure {
+            //public void Configure()
+
+            static void Postfix(global::Needs.NeedManager __instance) {
+                foreach( var need in __instance.needs ) {
+                    need.Configure();
+                }
+            }
+        }
+    }
+}

--- a/SimAirport.Modding.Base/Data/ImplementationDetails/NeedPatches.cs
+++ b/SimAirport.Modding.Base/Data/ImplementationDetails/NeedPatches.cs
@@ -3,18 +3,13 @@ using Newtonsoft.Json;
 using System;
 
 namespace SimAirport.Modding.Data.NewInternals {
-    class NeedPatches {
-
-
+    internal static class NeedPatches {
         /// <summary>
-        /// Interface which modded needs _must_ implemenent.
-        /// 
-        /// It provides hooks for the ingame logic to call custom behaviour.
-        /// 
-        /// May be integrated directly into Needs.Need class?
+        /// <para>Interface which modded needs _must_ implemenent.</para>
+        /// <para>It provides hooks for the ingame logic to call custom behaviour.</para>
+        /// <para>May be integrated directly into Needs.Need class?</para>
         /// </summary>
         public class Need_Modifications : Need {
-
             /// <summary>
             /// Translation key for the need's name.
             /// </summary>
@@ -32,15 +27,12 @@ namespace SimAirport.Modding.Data.NewInternals {
                 }
             }
 
-
             /// <summary>
             /// Called for each new agent (like pax, executives) to configure the need for
             /// each individually.
             /// </summary>
             public virtual void Configure() { }
         }
-
-
 
         /***
             * Attach hook to NeedManager.AddAllNeeds
@@ -52,10 +44,10 @@ namespace SimAirport.Modding.Data.NewInternals {
             */
         [HarmonyPatch(typeof(NeedManager))]
         [HarmonyPatch("AddAllNeeds")]
-        static class NeedManager_AddAllNeeds {
+        internal static class NeedManager_AddAllNeeds {
             //private void AddAllNeeds()
 
-            static void Postfix(global::Needs.NeedManager __instance) {
+            public static void Postfix(global::Needs.NeedManager __instance) {
                 foreach( var needType in NeedManagerInternals.customNeedTypes ) {
                     // NeedManager.Add<> is private and looking it up is more complex than just reimplement add.
                     // This block is almost identical to NeedManager.Add<T>
@@ -79,10 +71,10 @@ namespace SimAirport.Modding.Data.NewInternals {
             */
         [HarmonyPatch(typeof(global::Needs.NeedManager))]
         [HarmonyPatch(nameof(global::Needs.NeedManager.Configure))]
-        static class NeedManager_Configure {
+        internal static class NeedManager_Configure {
             //public void Configure()
 
-            static void Postfix(global::Needs.NeedManager __instance) {
+            public static void Postfix(global::Needs.NeedManager __instance) {
                 foreach( var need in __instance.needs ) {
                     need.Configure();
                 }

--- a/SimAirport.Modding.Base/Data/ImplementationDetails/ZoneManagerInternals.cs
+++ b/SimAirport.Modding.Base/Data/ImplementationDetails/ZoneManagerInternals.cs
@@ -2,17 +2,15 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using TerrainTools;
 using UnityEngine;
 
 namespace SimAirport.Modding.Data.NewInternals {
-    class ZoneManagerInternals {
+    internal static class ZoneManagerInternals {
         /*
-        * The following is just for pipelining type information through Zone.ZoneType Enum
-        */
-        private static readonly int zone_type_id_start = 1000;
+         * The following is just for pipelining type information through Zone.ZoneType Enum
+         */
+        private const int zone_type_id_start = 1000;
         private static int _nextFreeZoneId = zone_type_id_start;
         private static int NextFreeZoneId {
             get {
@@ -20,7 +18,7 @@ namespace SimAirport.Modding.Data.NewInternals {
             }
         }
 
-        private static Dictionary<Zone.ZoneType, string> ZoneTypeToUniqueId = new Dictionary<Zone.ZoneType, string>();
+        private static readonly Dictionary<Zone.ZoneType, string> ZoneTypeToUniqueId = new Dictionary<Zone.ZoneType, string>();
         internal static bool IsZoneTypeModding(Zone.ZoneType type) {
             return (int) type >= zone_type_id_start;
         }
@@ -40,10 +38,8 @@ namespace SimAirport.Modding.Data.NewInternals {
          * Pipeline Helpers End
          */
 
-
         // Map which Zone type is instanciated by which modded zone tool
         internal static Dictionary<string, Type> ToolToZoneType = new Dictionary<string, Type>();
-
 
         public static ZoneTool InternalRegisterZone(Type zoneType, string uniqueId, ZoneToolConfig config) { // where Type : Zone
             ZoneTool.LoadAll(); // force load of vanilla zones, else they will never be loaded!
@@ -52,10 +48,8 @@ namespace SimAirport.Modding.Data.NewInternals {
             if( !ZTools.TryGetValue(uniqueId, out ZoneTool zoneTool) ) {
                 zoneTool = ScriptableObject.CreateInstance<ZoneTool>();
 
-
                 config.zone_type = (Zone.ZoneType) NextFreeZoneId;  // currently missusing it to transport information to Zone.Create
                 config.zone_type = Zone.ZoneType.Modded;           // this is what you have suggested
-
 
                 zoneTool.zone_config = config;
 
@@ -63,7 +57,6 @@ namespace SimAirport.Modding.Data.NewInternals {
                 zoneTool.uniqueID = uniqueId;
                 zoneTool.i18nNameKey = config.I18nNameKey;
                 zoneTool.i18nDescKey = config.I18nDescKey;
-
 
                 ZoneTypeToUniqueId.Add(config.zone_type, uniqueId);
 
@@ -73,8 +66,6 @@ namespace SimAirport.Modding.Data.NewInternals {
             }
             return zoneTool;
         }
-
-
 
         public static void InternalUnregisterZone(ZoneTool zoneTool) {
             var ZTools = ZonePatches.GetZTools();

--- a/SimAirport.Modding.Base/Data/ImplementationDetails/ZoneManagerInternals.cs
+++ b/SimAirport.Modding.Base/Data/ImplementationDetails/ZoneManagerInternals.cs
@@ -1,0 +1,102 @@
+﻿using SimAirport.Modding.Data.ImplementationDetails;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TerrainTools;
+using UnityEngine;
+
+namespace SimAirport.Modding.Data.NewInternals {
+    class ZoneManagerInternals {
+        /*
+        * The following is just for pipelining type information through Zone.ZoneType Enum
+        */
+        private static readonly int zone_type_id_start = 1000;
+        private static int _nextFreeZoneId = zone_type_id_start;
+        private static int NextFreeZoneId {
+            get {
+                return _nextFreeZoneId++;
+            }
+        }
+
+        private static Dictionary<Zone.ZoneType, string> ZoneTypeToUniqueId = new Dictionary<Zone.ZoneType, string>();
+        internal static bool IsZoneTypeModding(Zone.ZoneType type) {
+            return (int) type >= zone_type_id_start;
+        }
+
+        internal static string ModdedZoneTypeToUid(Zone.ZoneType type) {
+            if( !IsZoneTypeModding(type) ) {
+                return type.ToString();
+            } else {
+                return ZoneTypeToUniqueId[type];
+            }
+        }
+        internal static Zone.ZoneType? ModdedUidToZoneType(string uid) {
+            return ZoneTypeToUniqueId.Where(e => e.Value == uid).Select(e => (Zone.ZoneType?) e.Key).FirstOrDefault();
+        }
+
+        /*
+         * Pipeline Helpers End
+         */
+
+
+        // Map which Zone type is instanciated by which modded zone tool
+        internal static Dictionary<string, Type> ToolToZoneType = new Dictionary<string, Type>();
+
+
+        public static ZoneTool InternalRegisterZone(Type zoneType, string uniqueId, ZoneToolConfig config) { // where Type : Zone
+            ZoneTool.LoadAll(); // force load of vanilla zones, else they will never be loaded!
+            var ZTools = ZonePatches.GetZTools();
+
+            if( !ZTools.TryGetValue(uniqueId, out ZoneTool zoneTool) ) {
+                zoneTool = ScriptableObject.CreateInstance<ZoneTool>();
+
+
+                config.zone_type = (Zone.ZoneType) NextFreeZoneId;  // currently missusing it to transport information to Zone.Create
+                config.zone_type = Zone.ZoneType.Modded;           // this is what you have suggested
+
+
+                zoneTool.zone_config = config;
+
+                zoneTool.name = (config.name = uniqueId);
+                zoneTool.uniqueID = uniqueId;
+                zoneTool.i18nNameKey = config.I18nNameKey;
+                zoneTool.i18nDescKey = config.I18nDescKey;
+
+
+                ZoneTypeToUniqueId.Add(config.zone_type, uniqueId);
+
+                ToolToZoneType.Add(uniqueId, zoneType);
+
+                ZTools.Add(uniqueId, zoneTool);
+            }
+            return zoneTool;
+        }
+
+
+
+        public static void InternalUnregisterZone(ZoneTool zoneTool) {
+            var ZTools = ZonePatches.GetZTools();
+
+            if( zoneTool != null ) {
+                string uniqueId = zoneTool.uniqueID;
+                Zone.ZoneType zoneType = zoneTool.zone_type;
+
+                ZTools.Remove(uniqueId);
+                ToolToZoneType.Remove(uniqueId);
+                ZoneTypeToUniqueId.Remove(zoneType);
+            }
+        }
+
+        internal static Zone CreateZone(string uid, int predetermined_guid) {
+            Type zonetype = ToolToZoneType[uid];
+            Zone zone = (Zone)Activator.CreateInstance(zonetype, (Zone.ZoneType)zone_type_id_start );
+
+            zone.iprefab.guid = predetermined_guid < 0 ? GUID.New() : predetermined_guid;
+            Util.AddSafe(ref global::Game.current.iprefabs, zone.iprefab);
+
+            return zone;
+        }
+    }
+}

--- a/SimAirport.Modding.Base/Data/ImplementationDetails/ZonePatches.cs
+++ b/SimAirport.Modding.Base/Data/ImplementationDetails/ZonePatches.cs
@@ -1,0 +1,194 @@
+﻿using HarmonyLib;
+using SimAirport.Modding.Data.NewInternals;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using TerrainTools;
+using UnityEngine;
+
+namespace SimAirport.Modding.Data.ImplementationDetails {
+    class ZonePatches {
+
+        public class ZoneToolConfig_Modifications : ZoneToolConfig {
+            // expected Additions/Changes to ZoneToolConfig:
+
+            public string I18nNameKey = "UI.zones.zone.name"; // fill with default key for "Zone"
+            public string I18nDescKey = "UI.zones.zone.desc"; // fill with default key
+            public string ZoneSpriteKey = "ZoneDiagonal_???"; // fill with default sprite key
+            public string ToolSpriteKey = "ZoneDiagonal_???"; // fill with default sprite key
+
+            public string localizedNameKey { // may need some refinement for zone menu to show prefix "[MOD]"
+                get {
+                    if( zone_type == Zone.ZoneType.Modded ) {
+                        return I18nNameKey;
+                    } else {
+                        return $"UI.zones.{zone_type.ToString()}.name";
+                    }
+                }
+            }
+
+            public string localizedDescription {
+                get {
+                    if( zone_type == Zone.ZoneType.Modded ) {
+                        return i18n.Get(I18nDescKey);
+                    } else {
+                        return i18n.Get($"UI.zones.{zone_type.ToString()}.description");
+                    }
+                }
+            }
+            public Sprite zoneSprite {
+                get {
+                    if( zone_type == Zone.ZoneType.Modded ) {
+                        return SpriteManager.Get(ZoneSpriteKey);
+                    } else {
+                        return SpriteManager.Get("ZoneDiagonal_" + spriteSuffix);
+                    }
+                }
+            }
+        }
+
+        public class ZoneTool_Modifications : TerrainTools.ZoneTool {
+            public string spriteName {
+                get {
+                    if( zone_config.zone_type == Zone.ZoneType.None ) {
+                        return "ZoneRemoveIcon";
+                    } else if( zone_config.zone_type == Zone.ZoneType.Modded ) {
+                        return zone_config.ToolSpriteKey;
+                    } else {
+                        return "ZoneDiagonal_" + zone_config.spriteSuffix;
+                    }
+                }
+            }
+        }
+
+
+
+        /***
+         * Helper to access ZoneTool.ZTools
+         * 
+         * The "one" zone tool storage dict.
+         */
+        public static Dictionary<string, ZoneTool> GetZTools() {
+            // Get ZoneTool.ZTools
+            var ZTools_raw = typeof(ZoneTool).GetField("ZTools", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public).GetValue(null);
+
+            return ZTools_raw as Dictionary<string, ZoneTool>;
+        }
+
+
+        /***************************************************
+         * 
+         *            Zone Type List & Lookup
+         * 
+         ***************************************************/
+
+
+        /***
+         * Extend lookup also into modded zones
+         */
+        [HarmonyPatch(typeof(ZoneToolConfig))]
+        [HarmonyPatch(nameof(ZoneToolConfig.GetZoneToolConfigByType))]
+        static class ZoneToolConfig_GetZoneToolConfigByType {
+
+            static void Postfix(ref ZoneToolConfig __result, Zone.ZoneType zt) {
+                if( __result == null ) {
+
+                    if( ZoneManagerInternals.IsZoneTypeModding(zt) ) {
+                        var uid = ZoneManagerInternals.ModdedZoneTypeToUid(zt);
+
+                        var ZTools = GetZTools();
+
+                        __result = ZTools[uid].zone_config;
+                    }
+                }
+            }
+        }
+
+        /***
+        * Delegate the custom zone creation for modded zone zools
+        */
+        [HarmonyPatch(typeof(Zone))]
+        [HarmonyPatch(nameof(Zone.Create))]
+        [HarmonyPatch(new Type[] { typeof(Zone.ZoneType), typeof(int) })]
+        static class Patch_Zone_Create_ZoneType {
+
+            static bool Prefix(Zone.ZoneType type, int predetermined_guid, ref Zone __result) {
+                // if it's a modded type, delegate to Handler
+
+                if( ZoneManagerInternals.IsZoneTypeModding(type) ) {
+                    var uid = ZoneManagerInternals.ModdedZoneTypeToUid(type);
+
+                    __result = ZoneManagerInternals.CreateZone(uid, predetermined_guid);
+
+                    return false;
+                }
+
+                return true;
+            }
+        }
+
+
+        /***********************************************
+         * 
+         * The lower stuff is transforming the zone type
+         * into the zone uid and vice versa.
+         * 
+         * It's mainly for piping the type through the
+         * ZoneType Enum.
+         * 
+         ***********************************************/
+
+
+        /***
+         * Translate zone_type (int) => zone name
+         * 
+         * Savegames require unique persistent zone names, but the name is derived
+         * from the used Zone_Type Enum. Custom zones do use an integer internally,
+         * which is not nessesarily persistent over multiple loads.
+         * 
+         * This was the best solution I came up with, postfixing the Enum.ToString method:
+         * 
+         * For the ZoneType Enum, it looksup the zone tool name.
+         */
+        [HarmonyPatch(typeof(Enum), "ToString", new Type[] { })]
+        static class Patch_Enum_ToString {
+            static void Postfix(Enum __instance, ref string __result) {
+                if( __instance.GetType().Equals(typeof(Zone.ZoneType)) ) {
+                    if( int.TryParse(__result, out int asInt) ) {
+                        __result = ZoneManagerInternals.ModdedZoneTypeToUid((Zone.ZoneType) asInt);
+                    }
+                }
+            }
+        }
+
+
+        /***
+         * Reverse translation zone name => zone_type (int)
+         * 
+         * Reverse mapping of the above mapping.
+         * 
+         * The string is loaded from savegame and is translated to the current zone_type.
+         * For this, the path_string is prepared to only contain a number to be parsed successfully.
+         */
+        [HarmonyPatch(typeof(Zone))]
+        [HarmonyPatch(nameof(Zone.Create))]
+        [HarmonyPatch(new Type[] { typeof(string), typeof(int) })]
+        static class Patch_Zone_Create_string {
+
+            static void Prefix(ref string path_string, int predetermined_guid) {
+                // normal path_string format: ZONE/LOOKUP42
+                // modify path_string, so path_string.Replace("ZONE/", "") => 42
+
+                var s = path_string.Replace("ZONE/", "");
+
+                var type = ZoneManagerInternals.ModdedUidToZoneType(s);
+
+                if( type != null ) {
+                    path_string = ((int) type).ToString();
+                }
+            }
+        }
+
+
+    }
+}

--- a/SimAirport.Modding.Base/Data/ImplementationDetails/ZonePatches.cs
+++ b/SimAirport.Modding.Base/Data/ImplementationDetails/ZonePatches.cs
@@ -1,5 +1,4 @@
-﻿using HarmonyLib;
-using SimAirport.Modding.Data.NewInternals;
+﻿using SimAirport.Modding.Data.NewInternals;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -7,8 +6,7 @@ using TerrainTools;
 using UnityEngine;
 
 namespace SimAirport.Modding.Data.ImplementationDetails {
-    class ZonePatches {
-
+    internal static class ZonePatches {
         public class ZoneToolConfig_Modifications : ZoneToolConfig {
             // expected Additions/Changes to ZoneToolConfig:
 
@@ -61,8 +59,6 @@ namespace SimAirport.Modding.Data.ImplementationDetails {
             }
         }
 
-
-
         /***
          * Helper to access ZoneTool.ZTools
          * 
@@ -75,24 +71,20 @@ namespace SimAirport.Modding.Data.ImplementationDetails {
             return ZTools_raw as Dictionary<string, ZoneTool>;
         }
 
-
         /***************************************************
          * 
          *            Zone Type List & Lookup
          * 
          ***************************************************/
 
-
         /***
          * Extend lookup also into modded zones
          */
         [HarmonyPatch(typeof(ZoneToolConfig))]
         [HarmonyPatch(nameof(ZoneToolConfig.GetZoneToolConfigByType))]
-        static class ZoneToolConfig_GetZoneToolConfigByType {
-
-            static void Postfix(ref ZoneToolConfig __result, Zone.ZoneType zt) {
+        internal static class ZoneToolConfig_GetZoneToolConfigByType {
+            public static void Postfix(ref ZoneToolConfig __result, Zone.ZoneType zt) {
                 if( __result == null ) {
-
                     if( ZoneManagerInternals.IsZoneTypeModding(zt) ) {
                         var uid = ZoneManagerInternals.ModdedZoneTypeToUid(zt);
 
@@ -110,9 +102,8 @@ namespace SimAirport.Modding.Data.ImplementationDetails {
         [HarmonyPatch(typeof(Zone))]
         [HarmonyPatch(nameof(Zone.Create))]
         [HarmonyPatch(new Type[] { typeof(Zone.ZoneType), typeof(int) })]
-        static class Patch_Zone_Create_ZoneType {
-
-            static bool Prefix(Zone.ZoneType type, int predetermined_guid, ref Zone __result) {
+        internal static class Patch_Zone_Create_ZoneType {
+            public static bool Prefix(Zone.ZoneType type, int predetermined_guid, ref Zone __result) {
                 // if it's a modded type, delegate to Handler
 
                 if( ZoneManagerInternals.IsZoneTypeModding(type) ) {
@@ -127,7 +118,6 @@ namespace SimAirport.Modding.Data.ImplementationDetails {
             }
         }
 
-
         /***********************************************
          * 
          * The lower stuff is transforming the zone type
@@ -137,7 +127,6 @@ namespace SimAirport.Modding.Data.ImplementationDetails {
          * ZoneType Enum.
          * 
          ***********************************************/
-
 
         /***
          * Translate zone_type (int) => zone name
@@ -151,8 +140,8 @@ namespace SimAirport.Modding.Data.ImplementationDetails {
          * For the ZoneType Enum, it looksup the zone tool name.
          */
         [HarmonyPatch(typeof(Enum), "ToString", new Type[] { })]
-        static class Patch_Enum_ToString {
-            static void Postfix(Enum __instance, ref string __result) {
+        internal static class Patch_Enum_ToString {
+            public static void Postfix(Enum __instance, ref string __result) {
                 if( __instance.GetType().Equals(typeof(Zone.ZoneType)) ) {
                     if( int.TryParse(__result, out int asInt) ) {
                         __result = ZoneManagerInternals.ModdedZoneTypeToUid((Zone.ZoneType) asInt);
@@ -160,7 +149,6 @@ namespace SimAirport.Modding.Data.ImplementationDetails {
                 }
             }
         }
-
 
         /***
          * Reverse translation zone name => zone_type (int)
@@ -173,9 +161,8 @@ namespace SimAirport.Modding.Data.ImplementationDetails {
         [HarmonyPatch(typeof(Zone))]
         [HarmonyPatch(nameof(Zone.Create))]
         [HarmonyPatch(new Type[] { typeof(string), typeof(int) })]
-        static class Patch_Zone_Create_string {
-
-            static void Prefix(ref string path_string, int predetermined_guid) {
+        internal static class Patch_Zone_Create_string {
+            public static void Prefix(ref string path_string, int predetermined_guid) {
                 // normal path_string format: ZONE/LOOKUP42
                 // modify path_string, so path_string.Replace("ZONE/", "") => 42
 
@@ -188,7 +175,5 @@ namespace SimAirport.Modding.Data.ImplementationDetails {
                 }
             }
         }
-
-
     }
 }

--- a/SimAirport.Modding.Base/Data/NeedManager.cs
+++ b/SimAirport.Modding.Base/Data/NeedManager.cs
@@ -3,9 +3,7 @@ using System;
 
 namespace SimAirport.Modding.Data {
     public class NeedManager {
-
         public static NeedManager Instance { get; private set; }
-
 
         /// <summary>
         /// Creates singleton of this manager.
@@ -22,7 +20,6 @@ namespace SimAirport.Modding.Data {
             InternalUnregisterNeed = internalUnregisterNeed;
         }
 
-
         /// <summary>
         /// Register a new need to the game.
         /// </summary>
@@ -31,7 +28,6 @@ namespace SimAirport.Modding.Data {
             InternalRegisterNeed(typeof(T));
         }
         private readonly Action<Type> InternalRegisterNeed;
-
 
         /// <summary>
         /// Unregisters the given need.

--- a/SimAirport.Modding.Base/Data/NeedManager.cs
+++ b/SimAirport.Modding.Base/Data/NeedManager.cs
@@ -1,0 +1,45 @@
+﻿using Needs;
+using System;
+
+namespace SimAirport.Modding.Data {
+    public class NeedManager {
+
+        public static NeedManager Instance { get; private set; }
+
+
+        /// <summary>
+        /// Creates singleton of this manager.
+        /// </summary>
+        /// <param name="internalRegisterNeed">NeedManagerInternal.InternalRegisterNeed</param>
+        /// <param name="internalUnregisterNeed">NeedManagerInternal.InternalUnregisterNeed</param>
+        public NeedManager(Action<Type> internalRegisterNeed, Action<Type> internalUnregisterNeed) {
+            if( Instance != null )
+                throw new InvalidOperationException("Tried to create 2nd " + GetType().Name);
+
+            Instance = this;
+
+            InternalRegisterNeed = internalRegisterNeed;
+            InternalUnregisterNeed = internalUnregisterNeed;
+        }
+
+
+        /// <summary>
+        /// Register a new need to the game.
+        /// </summary>
+        /// <typeparam name="T">The class defining the new need.</typeparam>
+        public void RegisterNeed<T>() where T : Need, new() {
+            InternalRegisterNeed(typeof(T));
+        }
+        private readonly Action<Type> InternalRegisterNeed;
+
+
+        /// <summary>
+        /// Unregisters the given need.
+        /// </summary>
+        /// <typeparam name="T">The class defining the new need.</typeparam>
+        public void UnregisterNeed<T>() where T : Need {
+            InternalUnregisterNeed(typeof(T));
+        }
+        private readonly Action<Type> InternalUnregisterNeed;
+    }
+}

--- a/SimAirport.Modding.Base/Data/ZoneManager.cs
+++ b/SimAirport.Modding.Base/Data/ZoneManager.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using TerrainTools;
+
+namespace SimAirport.Modding.Data {
+    public class ZoneManager {
+
+        public static ZoneManager Instance { get; private set; }
+
+
+        /// <summary>
+        /// Creates singleton of this manager.
+        /// </summary>
+        /// <param name="internalRegisterZone">ZoneManagerInternal.InternalRegisterZone</param>
+        /// <param name="internalUnregisterZone">ZoneManagerInternal.InternalUnregisterZone</param>
+        public ZoneManager(Func<Type, string, ZoneToolConfig, ZoneTool> internalRegisterZone, Action<ZoneTool> internalUnregisterZone) {
+            if( Instance != null )
+                throw new InvalidOperationException("Tried to create 2nd " + GetType().Name);
+
+            Instance = this;
+
+            InternalRegisterZone = internalRegisterZone;
+            InternalUnregisterZone = internalUnregisterZone;
+        }
+
+
+        /// <summary>
+        /// Registers a new zone.
+        /// </summary>
+        /// <typeparam name="T">Zone Derivative with zone's logic</typeparam>
+        /// <param name="config"></param>
+        /// <param name="uniqueId">globally unique zone identifier</param>
+        /// <param name="i18nNameKey">zone name shown in menu and as overlay</param>
+        /// <param name="i18nDescKey">description of the zone in the build menu</param>
+        /// <returns>Zone Tool instance representing the new build tool</returns>
+        public ZoneTool RegisterZone<T>(string uniqueId, ZoneToolConfig config) where T : Zone {
+            return InternalRegisterZone(typeof(T), uniqueId, config);
+        }
+        private readonly Func<Type, string, ZoneToolConfig, ZoneTool> InternalRegisterZone;
+
+
+        /// <summary>
+        /// Remove a zone tool.
+        /// </summary>
+        /// <param name="which">The zone tool to be unregistered from the game.</param>
+        public void UnregisterZone(ZoneTool which) {
+            InternalUnregisterZone(which);
+        }
+        private readonly Action<ZoneTool> InternalUnregisterZone;
+
+    }
+}

--- a/SimAirport.Modding.Base/Data/ZoneManager.cs
+++ b/SimAirport.Modding.Base/Data/ZoneManager.cs
@@ -3,9 +3,7 @@ using TerrainTools;
 
 namespace SimAirport.Modding.Data {
     public class ZoneManager {
-
         public static ZoneManager Instance { get; private set; }
-
 
         /// <summary>
         /// Creates singleton of this manager.
@@ -22,21 +20,17 @@ namespace SimAirport.Modding.Data {
             InternalUnregisterZone = internalUnregisterZone;
         }
 
-
         /// <summary>
         /// Registers a new zone.
         /// </summary>
         /// <typeparam name="T">Zone Derivative with zone's logic</typeparam>
-        /// <param name="config"></param>
         /// <param name="uniqueId">globally unique zone identifier</param>
-        /// <param name="i18nNameKey">zone name shown in menu and as overlay</param>
-        /// <param name="i18nDescKey">description of the zone in the build menu</param>
+        /// <param name="config"></param>
         /// <returns>Zone Tool instance representing the new build tool</returns>
         public ZoneTool RegisterZone<T>(string uniqueId, ZoneToolConfig config) where T : Zone {
             return InternalRegisterZone(typeof(T), uniqueId, config);
         }
         private readonly Func<Type, string, ZoneToolConfig, ZoneTool> InternalRegisterZone;
-
 
         /// <summary>
         /// Remove a zone tool.
@@ -46,6 +40,5 @@ namespace SimAirport.Modding.Data {
             InternalUnregisterZone(which);
         }
         private readonly Action<ZoneTool> InternalUnregisterZone;
-
     }
 }


### PR DESCRIPTION
Proposal for a new modding API addition with internal implementation detail as reference.

This pull request depends of a few changes in the game classes to provide mod-abilities for custom needs and zones. Mostly, these are UI relevant changes such as internationalization and sprite selection. Those values are somewhat hard coded.

This PR includes the method patches I used for the proof-of-concept:
![proof-of-concept](https://user-images.githubusercontent.com/65818738/83304849-dc1f6980-a1ff-11ea-8413-f729e03404aa.png)
As dynamic patching does not allow for addition or modification of fields, I was stuck on creating patch methods. For many i18n issues, adding fields is the better option. Therefore, I proposed changed to some in-game classes more suited for those tasks - with the drawback that the project can not be compiled because of missing fields and invalid assignments. Please keep in mind, that the implementation details are only one possible _I_ would intend to implement.

On this note I should also address the `zone_type` field in ` ZoneToolConfig`: I used heavy weaponry on this Enum to extend it to modded zones. As Enums only allow integers, I used a lookup table for translating between unique string ids and type enum ids, which is mainly used for saving and loading airports (which was fully supported in my proof-of-concept).

In addition to the front end API and the internal implementation proposal, an example was added. The later demonstrates how the proposed API is intended to be used by modders.

If this PR find's its way into the game, I'm willed to create a standalone example mod for the wiki.